### PR TITLE
feat: add Rust schema validation tests in CI

### DIFF
--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  validate-schemas:
+  validate-schemas-js:
     runs-on: ubuntu-latest
 
     steps:
@@ -29,3 +29,25 @@ jobs:
       - name: Validate against upstream schemata (kind 14, 15, 10050, 13, 1059)
         working-directory: ./test-vectors
         run: node validate-schemata.js
+
+  validate-schemas-rust:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust/target
+          key: ${{ runner.os }}-cargo-schema-${{ hashFiles('rust/Cargo.lock') }}
+
+      - name: Run schema validation tests
+        working-directory: ./rust
+        run: cargo test --test schema_validation

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -47,6 +47,8 @@ jobs:
             ~/.cargo/git
             rust/target
           key: ${{ runner.os }}-cargo-schema-${{ hashFiles('rust/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-schema-
 
       - name: Run schema validation tests
         working-directory: ./rust

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,6 +8,8 @@ repository = "https://github.com/alltheseas/bugstr"
 keywords = ["nostr", "crash-reporting", "nip-17", "privacy"]
 categories = ["development-tools::debugging"]
 
+[workspace]
+
 [[bin]]
 name = "bugstr"
 path = "src/bin/main.rs"
@@ -48,3 +50,8 @@ tempfile = "3.14"
 semver = "1.0"
 
 [dev-dependencies]
+schemata-validator-rs = { git = "https://github.com/nostrability/schemata-validator-rs.git" }
+schemata-rs = { git = "https://github.com/nostrability/schemata-rs.git" }
+
+[patch."https://github.com/nostrability/schemata-validator-rs.git"]
+schemata-rs = { git = "https://github.com/nostrability/schemata-rs.git" }

--- a/rust/tests/schema_validation.rs
+++ b/rust/tests/schema_validation.rs
@@ -185,14 +185,12 @@ fn wrong_kind_fails_validation() {
         "sig": sig128('c')
     });
 
-    // Validate as kind 0 schema — kind mismatch should fail
-    if let Some(schema) = get_schema("kind0Schema") {
-        let result = validate(schema, &note);
-        assert!(
-            !result.valid,
-            "kind 1 note should fail kind 0 schema validation"
-        );
-    }
+    let schema = get_schema("kind0Schema").expect("kind0Schema should exist");
+    let result = validate(schema, &note);
+    assert!(
+        !result.valid,
+        "kind 1 note should fail kind 0 schema validation"
+    );
 }
 
 #[test]
@@ -206,11 +204,10 @@ fn missing_pubkey_fails_validation() {
         "sig": sig128('c')
     });
 
-    if let Some(schema) = get_schema("noteSchema") {
-        let result = validate(schema, &note);
-        assert!(
-            !result.valid,
-            "event missing pubkey should fail validation"
-        );
-    }
+    let schema = get_schema("noteSchema").expect("noteSchema should exist");
+    let result = validate(schema, &note);
+    assert!(
+        !result.valid,
+        "event missing pubkey should fail validation"
+    );
 }

--- a/rust/tests/schema_validation.rs
+++ b/rust/tests/schema_validation.rs
@@ -1,0 +1,216 @@
+//! Schema validation tests for bugstr's Nostr event construction.
+//!
+//! Validates that events produced by bugstr conform to the canonical
+//! nostrability/schemata definitions. These run in CI to catch schema
+//! drift at build time rather than at runtime.
+
+use bugstr::UnsignedNostrEvent;
+use schemata_validator_rs::{validate, validate_note, get_schema};
+
+fn hex64(c: char) -> String {
+    std::iter::repeat(c).take(64).collect()
+}
+
+fn sig128(c: char) -> String {
+    std::iter::repeat(c).take(128).collect()
+}
+
+/// Convert an UnsignedNostrEvent to schema-valid JSON.
+///
+/// Bugstr includes `sig: ""` in rumor JSON for client compatibility (0xchat etc),
+/// but NIP-17 schemata says `sig` must NOT be present on unsigned events.
+/// Strip it before schema validation.
+fn to_schema_value(event: &UnsignedNostrEvent) -> serde_json::Value {
+    let mut value = serde_json::to_value(event).unwrap();
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("sig");
+    }
+    value
+}
+
+// -- Kind 14: NIP-17 Rumor (unsigned DM) --
+
+#[test]
+fn kind14_rumor_validates() {
+    let event = UnsignedNostrEvent::new(
+        hex64('a'),
+        1700000000,
+        14,
+        vec![vec!["p".into(), hex64('b')]],
+        "crash report payload",
+    )
+    .with_id();
+
+    let value = to_schema_value(&event);
+    let result = validate_note(&value);
+
+    assert!(
+        result.valid,
+        "kind 14 rumor should validate. errors: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn kind14_rumor_with_reply_tag_validates() {
+    let event = UnsignedNostrEvent::new(
+        hex64('a'),
+        1700000000,
+        14,
+        vec![
+            vec!["p".into(), hex64('b')],
+            vec!["e".into(), hex64('c'), "wss://relay.example.com".into(), "reply".into()],
+        ],
+        "crash report payload",
+    )
+    .with_id();
+
+    let value = to_schema_value(&event);
+    let result = validate_note(&value);
+
+    assert!(
+        result.valid,
+        "kind 14 rumor with reply tag should validate. errors: {:?}",
+        result.errors
+    );
+}
+
+// -- Kind 1: basic note (smoke test that validator works) --
+
+#[test]
+fn kind1_note_validates() {
+    let note = serde_json::json!({
+        "id": hex64('a'),
+        "pubkey": hex64('b'),
+        "created_at": 1700000000u64,
+        "kind": 1,
+        "tags": [],
+        "content": "hello world",
+        "sig": sig128('c')
+    });
+
+    let result = validate_note(&note);
+
+    assert!(
+        result.valid,
+        "kind 1 note should validate. errors: {:?}",
+        result.errors
+    );
+}
+
+// -- Tag schema validation --
+
+#[test]
+fn p_tag_validates() {
+    let schema = get_schema("pTagSchema").expect("pTagSchema should exist");
+    let tag = serde_json::json!(["p", hex64('a')]);
+    let result = validate(schema, &tag);
+
+    assert!(
+        result.valid,
+        "p tag should validate. errors: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn e_tag_validates() {
+    let schema = get_schema("eTagSchema").expect("eTagSchema should exist");
+    let tag = serde_json::json!(["e", hex64('a'), "wss://relay.example.com", "reply"]);
+    let result = validate(schema, &tag);
+
+    assert!(
+        result.valid,
+        "e tag should validate. errors: {:?}",
+        result.errors
+    );
+}
+
+// -- Test vector: event ID computation --
+
+#[test]
+fn event_id_matches_test_vectors() {
+    let vectors = vec![
+        (
+            "simple_rumor_no_tags",
+            hex64('a'),
+            1234567890u64,
+            14u16,
+            vec![],
+            "test",
+            "1bc0c6ea8e0a72276ebeaf1c722028dc8b0841c09b141174bd5976adfe67a65d",
+        ),
+        (
+            "rumor_with_p_tag",
+            hex64('a'),
+            1234567890,
+            14,
+            vec![vec!["p".into(), hex64('b')]],
+            "hello world",
+            "34286c63206447cb43d92f93054e8edfc275211fe830c0549daabf578bb8c3f8",
+        ),
+        (
+            "content_with_special_chars",
+            hex64('a'),
+            1234567890,
+            14,
+            vec![],
+            "line1\nline2\ttab\"quote\\backslash",
+            "e1e055550ce8cf02766370d7a513888134f7e14d72050b6d76ddb40d57aafcbc",
+        ),
+    ];
+
+    for (name, pubkey, created_at, kind, tags, content, expected_id) in vectors {
+        let event = UnsignedNostrEvent::new(pubkey, created_at, kind, tags, content);
+        let computed = event.compute_id();
+        assert_eq!(
+            computed, expected_id,
+            "ID mismatch for vector '{}'",
+            name
+        );
+    }
+}
+
+// -- Negative tests: invalid events should fail --
+
+#[test]
+fn wrong_kind_fails_validation() {
+    let note = serde_json::json!({
+        "id": hex64('a'),
+        "pubkey": hex64('b'),
+        "created_at": 1700000000u64,
+        "kind": 1,
+        "tags": [],
+        "content": "hello",
+        "sig": sig128('c')
+    });
+
+    // Validate as kind 0 schema — kind mismatch should fail
+    if let Some(schema) = get_schema("kind0Schema") {
+        let result = validate(schema, &note);
+        assert!(
+            !result.valid,
+            "kind 1 note should fail kind 0 schema validation"
+        );
+    }
+}
+
+#[test]
+fn missing_pubkey_fails_validation() {
+    let note = serde_json::json!({
+        "id": hex64('a'),
+        "created_at": 1700000000u64,
+        "kind": 1,
+        "tags": [],
+        "content": "hello",
+        "sig": sig128('c')
+    });
+
+    if let Some(schema) = get_schema("noteSchema") {
+        let result = validate(schema, &note);
+        assert!(
+            !result.valid,
+            "event missing pubkey should fail validation"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `rust/tests/schema_validation.rs` with 8 tests validating bugstr's event construction against [nostrability/schemata](https://github.com/nostrability/schemata) definitions
- Extends CI workflow with a parallel `validate-schemas-rust` job
- Uses [schemata-validator-rs](https://github.com/nostrability/schemata-validator-rs) as a dev-dependency

### Tests added
| Test | What it validates |
|------|-------------------|
| `kind14_rumor_validates` | UnsignedNostrEvent → kind 14 schema |
| `kind14_rumor_with_reply_tag_validates` | Rumor with p + e tags |
| `kind1_note_validates` | Smoke test (basic note) |
| `p_tag_validates` | p tag against pTagSchema |
| `e_tag_validates` | e tag against eTagSchema |
| `event_id_matches_test_vectors` | ID computation against 3 test vectors |
| `wrong_kind_fails_validation` | Negative: kind mismatch rejected |
| `missing_pubkey_fails_validation` | Negative: missing field rejected |

### Note on sig field
Bugstr includes `sig: ""` in rumor JSON for client compatibility (0xchat etc). The NIP-17 schema says `sig` must NOT be present on unsigned events. The test helper `to_schema_value()` strips `sig` before validation — this known divergence is documented in the code.

## Test plan
- [x] All 8 tests pass locally (`cargo test --test schema_validation`)
- [ ] CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive Rust schema validation test suite covering positive and negative cases, tag/event validation, and event ID correctness.

* **Chores**
  * CI expanded to run JavaScript and Rust schema validations in parallel.
  * Updated Rust project configuration and test dependencies to support the new validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->